### PR TITLE
Add handling for --exit and --quit commands

### DIFF
--- a/dbcl/command_line.py
+++ b/dbcl/command_line.py
@@ -112,6 +112,9 @@ def process_command(cmd, connection, args):
     cmd_argv = cmd.split()
     if cmd_argv[0] == '%sinfo' % _command_prefix:
         process_command_info(cmd_argv[1:], connection, args)
+    elif (cmd_argv[0] == '%sexit' % _command_prefix
+            or cmd_argv[0] == '%squit' % _command_prefix):
+        sys.exit(0)
     else:
         print('Bad command "%s"' % cmd)
 

--- a/tests/test_process_command.py
+++ b/tests/test_process_command.py
@@ -64,6 +64,25 @@ def test_info_missing_table(mocker, capsys):
     out, err = capsys.readouterr()
     assert out.startswith('No such table')
 
+def test_exit_no_args(mocker, capsys):
+    mock_args = mocker.MagicMock()
+    mock_args.database_url = 'test_db_url'
+    mock_metadata = mocker.patch('dbcl.command_line.MetaData')
+
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+            process_command('%sexit' % _command_prefix, None, mock_args)
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 0
+
+def test_quit_no_args(mocker, capsys):
+    mock_args = mocker.MagicMock()
+    mock_args.database_url = 'test_db_url'
+    mock_metadata = mocker.patch('dbcl.command_line.MetaData')
+
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+            process_command('%squit' % _command_prefix, None, mock_args)
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 0
 
 @pytest.mark.parametrize('command', (
     '%s%s' % (_command_prefix, cmd) for cmd in


### PR DESCRIPTION
I think a sys.exit(0) is appropriate when processing either --exit or --quit.  Let me know if I am taking the wrong approach or if there are some additional steps that should be taken.  I also wasn't sure whether quit or exit would be more appropriate here so I just implemented both.